### PR TITLE
Fixes mousdown event to just a few frames (instead of always clicking)

### DIFF
--- a/src/js/plugins/click.js
+++ b/src/js/plugins/click.js
@@ -1,8 +1,10 @@
 /**
- * Scrolls the page vertically
+ * Click on things
  */
-let mouseDowned = false
-let mouseDown = false
+// Number of frames mouse has been downed
+let mouseDowned = 0
+// Max number of frames to keep down
+let maxMouseDownedFrames = 5
 let mouseDrag = false
 let mouseUp = false
 let thresholdMet = false
@@ -17,30 +19,23 @@ Facepointer.use('click', (pointer, fp) => {
   })
 
   if (thresholdMet) {
-    mouseDrag = mouseDowned
-
-    // Every frame after first frame of click
-    if (mouseDowned) {
-      mouseDown = false
-    } else {
-      mouseDowned = true
-      mouseDown = true
-    }
+    mouseDowned++
     document.body.classList.add('facepointer-clicked')
   } else {
     mouseUp = mouseDowned
-    mouseDowned = mouseDrag = mouseDown = false
+    mouseDowned = 0
+    mouseDrag = mouseDown = false
     document.body.classList.remove('facepointer-clicked')
   }
 
   // Set the state
-  if (mouseDown) fp.pointer.state = 'mouseDown'
+  if (mouseDowned > 0 && mouseDowned < maxMouseDownedFrames) fp.pointer.state = 'mouseDown'
+  else if (mouseDowned > maxMouseDownedFrames) fp.pointer.state = 'mouseDrag'
   else if (mouseUp) fp.pointer.state = 'mouseUp'
-  else if (mouseDrag) fp.pointer.state = 'mouseDrag'
   else ''
 
   // Actually click something (or focus it)
-  if (mouseDowned) {
+  if (fp.pointer.state === 'mouseDown') {
     const $el = document.elementFromPoint(pointer.x, pointer.y)
     if ($el) {
       $el.dispatchEvent(new MouseEvent('click', {

--- a/src/sandbox.js
+++ b/src/sandbox.js
@@ -1,6 +1,6 @@
 /**
  * Facepointer plugin for drawing into Paper with face
- * - Adds `Facepointer_ReinitPaper()` to window. Call this method to clear the canvas
+ * - Adds `Facepointer_paperClear()` to window. Call this method to clear the canvas
  * 
  * @see http://paperjs.org/
  */
@@ -11,7 +11,7 @@ window.addEventListener('load', () => {
   let tool
   let lastPoint
   
-  Facepointer.use('paper-demo', pointer => {
+  Facepointer.use('paper-demo', (pointer, fp) => {
     /**
      * Click
      */
@@ -47,6 +47,13 @@ window.addEventListener('load', () => {
         lastPoint = getPoint(pointer)
       }
     }
+
+    /**
+     * Clear screen
+     */
+    if (fp.head.morphs[4] > 0.25 && fp.head.morphs[5] > 0.25) {
+      window.Facepointer_paperClear()
+    }
   })
   
   /**
@@ -64,11 +71,8 @@ window.addEventListener('load', () => {
   /**
    * Renitialize Paper.js
    */
-  window.Facepointer_ReinitPaper = function () {
-    paper.setup($canvas)
-    path = new paper.Path()
-    tool = new paper.Tool()
-    tool.minDistance = 20  
+  window.Facepointer_paperClear = function () {
+    paper.project.clear()
   }
   
   /**


### PR DESCRIPTION
There was a bug previously where a click event was called during mouseDown and not the first click. This resulted in accidentally clicking links if the cursor "swept" over the link while clicked. This also fixes a bug with clearing the drawing demo, which now works by raising your eyebrows.

In future releases, we'll add the ability to customize which face features/morphs to use for clicking.